### PR TITLE
Circulation cleanup.

### DIFF
--- a/src/graph/circulation.cpp
+++ b/src/graph/circulation.cpp
@@ -10,9 +10,7 @@ graph::CirculationResult graph::Circulation::has_circulation(graph::CirculationG
         return graph::CirculationResult::SUPPLY_NEQ_DEMAND;
     }
 
-    graph::FlowNetwork flow_net = G.asFlowNetwork();
-
-    int min_cut = graph::FordFulkerson::max_flow(flow_net);
+    int min_cut = graph::FordFulkerson::max_flow(G);
 
     if(min_cut != G.total_supply())
     {

--- a/src/graph/circulationgraph.cpp
+++ b/src/graph/circulationgraph.cpp
@@ -112,5 +112,25 @@ int graph::CirculationGraph::total_supply()
 
 int graph::CirculationGraph::total_demand()
 {
-   return m_total_demand;
+    return m_total_demand;
+}
+
+int graph::CirculationGraph::find_source()
+{
+    return 0; //0 is always the source for a circulation graph
+}
+
+int graph::CirculationGraph::find_sink()
+{
+    return 1; //1 is always the sink for a circulation graph
+}
+
+std::vector<int> graph::CirculationGraph::get_sources()
+{
+    return {0}; //0 is the only source node in a circulation graph
+}
+
+std::vector<int> graph::CirculationGraph::get_sinks()
+{
+    return {1}; //1 is the only sink node in a circulation graph
 }

--- a/src/graph/circulationgraph.hpp
+++ b/src/graph/circulationgraph.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "graph.hpp"
 #include <vector>
@@ -59,6 +59,32 @@ namespace graph
          * @return
          */
         int total_demand();
+
+        /**
+         * @brief The source will have no edges pointing to it
+         *
+         * This method assumes that the graph contains a single source
+         */
+        int find_source() override;
+
+        /**
+         * @brief The sink points to nothing
+         *
+         * This method assumes that the graph contains a single sink
+         */
+        virtual int find_sink() override;
+
+        /**
+         * @brief Find the sources for this graph
+         * @return a list of source-node indicies.
+         */
+        virtual std::vector<int> get_sources () override;
+
+        /**
+         * @brief Find the sinks for this graph
+         * @return a list of sink-node indicies.
+         */
+        virtual std::vector<int> get_sinks () override;
 
     private:
         int m_total_supply;

--- a/src/graph/flow_network.hpp
+++ b/src/graph/flow_network.hpp
@@ -63,14 +63,14 @@ public:
      * 
      * This method assumes that the graph contains a single source
      */
-    int find_source();
+    virtual int find_source();
 
     /**
      * @brief The sink points to nothing
      * 
      * This method assumes that the graph contains a single sink
      */
-    int find_sink();
+    virtual int find_sink();
 
     /**
      * @brief Reduce the capacity of the edge between the given nodes
@@ -103,13 +103,13 @@ public:
      * @brief Find the sources for this graph
      * @return a list of source-node indicies.
      */
-    std::vector<int> get_sources ();
+    virtual std::vector<int> get_sources ();
 
     /**
      * @brief Find the sinks for this graph
      * @return a list of sink-node indicies.
      */
-    std::vector<int> get_sinks ();
+    virtual std::vector<int> get_sinks ();
 
 //==============================================================================
 // Implementation Details


### PR DESCRIPTION
- Virtualized findSource(s)/Sink(s) methods
- removed conversion to FlowNetwork from has_circulation